### PR TITLE
passthrough non-dicts in update_spec

### DIFF
--- a/vsphere
+++ b/vsphere
@@ -367,6 +367,9 @@ class Vsphere(object):
              'name': 'vmname',
              'numCPUs': 1}
         """
+        if not isinstance(spec, dict):
+            return spec
+
         for spec_name, spec_value in spec.iteritems():
             # Ansible returns numbers as unicode
             try:


### PR DESCRIPTION
I ran into some difficulty attempting to alter network settings while using a VirtualMachineCloneSpec. 

Here's the `spec` attribute as defined in my playbook ... 

```
     spec:
        type: VirtualMachineCloneSpec
        value:
          config:
            VirtualMachineConfigSpec:
              name: "{{ inventory_hostname_short }}"
              memoryMB: "{{ memory }}"
              numCPUs: "{{ cpus }}"
              deviceChange: []
          location:
            VirtualMachineRelocateSpec:
              datastore:
                ManagedObjectReference:
                  type: Datastore
                  name: "{{ datastore }}"
              host:
                ManagedObjectReference:
                  type: HostSystem
                  name: "{{ esxhost }}"
          customization:
            CustomizationSpec:
              identity:
                CustomizationLinuxPrep:
                  domain: "{{ dnssuffix }}"
                  hostName:
                    CustomizationFixedName:
                      name: "{{ inventory_hostname_short}}"
              globalIPSettings:
                CustomizationGlobalIPSettings:
                  dnsServerList:
                    - "{{ ns1 }}"
                    - "{{ ns2 }}"
                  dnsSuffixList:
                    - "{{ dnssuffix }}"
              nicSettingMap:
                - CustomizationAdapterMapping:
                    adapter:
                      CustomizationIPSettings:
                        gateway: "{{ gateway }}"
                        subnetMask: "{{ mask }}"
                        ip:
                          CustomizationFixedIp:
                            ipAddress: "{{ address }}"
                        dnsDomain: "{{ dnssuffix }}"
                        dnsServerList:
                          - "{{ ns1 }}"
                          - "{{ ns2 }}"
```

Because all [nested list items are expected](https://github.com/ViaSat/ansible-vsphere/blob/master/vsphere#L388) to be dicts, I was hitting an AttributeError on [`spec.iteritems()` in `update_spec`](https://github.com/ViaSat/ansible-vsphere/blob/master/vsphere#L370) for `dnsServerList` (and `dnsSuffixList`).

I'm very new to the vsphere api, so I'm not sure if short-circuiting the recursion in this way is particularly safe, but it's what I did to get past the problem in my case. More likely, I'm just doing it all wrong. :smile: 

Thanks for sharing this supremely useful ansible module. 
