### PR TITLE
Update variable on host connect fail

### DIFF
--- a/vsphere
+++ b/vsphere
@@ -311,7 +311,7 @@ class Vsphere(object):
         try:
             self.si = SmartConnect(host = self.vsphere_host, user = login_username, pwd = login_password)
         except:
-            self.module.fail_json(msg = 'Could not connect to host %s' % self.host)
+            self.module.fail_json(msg = 'Could not connect to host %s' % self.vsphere_host)
 
         atexit.register(Disconnect, self.si)
 


### PR DESCRIPTION
Throws an error when unable to connect to the Vsphere host as self.host does not exist, should be self.vsphere_host
