### PR TITLE
Explicitly set source encoding to utf-8

### DIFF
--- a/vsphere
+++ b/vsphere
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+# -*- coding: utf-8 -*-
 
 # Copyright (c) 2014, ViaSat Inc. 
 #


### PR DESCRIPTION
Running this module in my environment produces the following encoding error:  "SyntaxError: Non-ASCII character '\xc2' in file /home/jossy/.ansible/tmp/ansible-tmp-1416602106.74-253057196686273/vsphere on line 3, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details"

To fix this problem, I've added a line which declares the (utf-8) encoding explicitly.
