### PR TITLE
Fix issues related to cloning many VMs in parallel

### DIFF
--- a/vsphere
+++ b/vsphere
@@ -30,11 +30,7 @@ try:
 except ImportError:
     import simplejson as json
 
-import re
-import os
-import time
 import atexit
-import urllib2
 import datetime
 import ast
 
@@ -335,7 +331,7 @@ class Vsphere(object):
         atexit.register(Disconnect, self.si)
 
     def _wait_task(self, task):
-        while task.info.state == vim.TaskInfo.State.running:
+        while (task.info.state != vim.TaskInfo.State.success and task.info.state != vim.TaskInfo.State.error):
             time.sleep(2)
 
         failed = False
@@ -344,8 +340,12 @@ class Vsphere(object):
                 ': %s' % task.info.result if task.info.result else '')
         else:
             failed = True
-            out = '%s did not complete successfully: %s' %(task.info.task,
-                task.info.error.msg)
+            if task.info.error:
+                out = '%s did not complete successfully: %s' %(task.info.task,
+                    task.info.error.msg)
+            else:
+                out = '%s did not complete successfully: with unknown error, state: %s' %(task.info.task,
+                                                                        task.info.state)
 
         return failed, out, task
 
@@ -362,7 +362,18 @@ class Vsphere(object):
 
         container = self.content.viewManager.CreateContainerView(limit, vimtype, recurse)
         if name is not None:
-            return [ c for c in container.view if c.name == name ][0]
+
+            def name_matches(child, name):
+                try:
+                    return child.name == name
+                except vmodl.fault.ManagedObjectNotFound:
+                    # This exception can be thrown (e.g. intermittently when creating multiple VMs in parallel)
+                    #   because we're trying to get properties of a child which is partway being created or deleted.
+                    # Ideally we'd like to check the name in a way which doesn't trigger exceptions, but for now
+                    #   we just ignore the exception to prevent it propagating and failing the module.
+                    return False
+
+            return [ c for c in container.view if name_matches(c, name)][0]
 
         return container.view
 


### PR DESCRIPTION
Hi, thanks for your library, it's useful!

I've noticed it sometimes gives an error when trying to clone/delete multiple VMs (e.g. 10+) in parallel: 
  msg: vmodl.fault.ManagedObjectNotFound: (vmodl.fault.ManagedObjectNotFound) {
     dynamicType = <unset>,
     dynamicProperty = (vmodl.DynamicProperty) [],
     msg = 'The object has already been deleted or has not been completely created',

Also noticed it can fail when vSphere is busy and has lots of other VMs being cloned in the queue:
   msg: AttributeError: 'NoneType' object has no attribute 'msg'
   Traceback (most recent call last):  
   File "/home/template/.ansible/tmp/ansible-tmp-1443713409.19-238703054661473/vsphere", line 934, in main    
      failed, result = core(module)  
   File "/home/template/.ansible/tmp/ansible-tmp-1443713409.19-238703054661473/vsphere", line 882, in core
      return v.clone_vm(guest, spec)
    File "/home/template/.ansible/tmp/ansible-tmp-1443713409.19-238703054661473/vsphere", line 689, in clone_vm
      failed, out, _ = self._wait_task(task)
    File "/home/template/.ansible/tmp/ansible-tmp-1443713409.19-238703054661473/vsphere", line 344, in _wait_task
      task.info.error.msg)AttributeError: 'NoneType' object has no attribute 'msg'

I've made some changes which seem to fix these, would you consider merging them in?
- Catch vmodl.fault.ManagedObjectNotFound when iterating through children when trying to look up machines. This error seems to be thrown when multiple VMs are cloned in parallel, and we try to get the name of one of the other VMs which is partway being cloned.
- Explicitly check for 'success' or 'error' state when waiting for job completion, instead of 'running', since there's a fourth 'queued' state. Doing it this way also seems to avoid some concurrency issues.

Thanks,
Jin