### PR TITLE
Set `no_log` on the password field

### DIFF
--- a/vsphere
+++ b/vsphere
@@ -962,7 +962,7 @@ def main():
         argument_spec = dict(
             host = dict(required=True),
             login = dict(required=True),
-            password = dict(required=True),
+            password = dict(required=True, no_log=True),
             checkssl=dict(required=False,default='true'),
             guest = dict(type='dict'),
             datacenter = dict(type = 'str'),


### PR DESCRIPTION
This is recommended on Ansible's [Developing Modules](http://docs.ansible.com/ansible/developing_modules.html). It instructs Ansible to scrub this value whenever it would print this module's configuration out.